### PR TITLE
Fixed mistakes, and propose a change.

### DIFF
--- a/fbut.md
+++ b/fbut.md
@@ -46,7 +46,7 @@ Use `ByteString`, not `ByteString.Char8`. If what you want is a conversion `Stri
 ``(a `op`)`` is not ``\x -> a `op` x``
 --------------------------------------
 
-These two forms are seeminly identical, but there is a subtle difference. The first one is just sugar for `op a`, while the second one is a lambda (and not direct application of `op`). This leads to This leads to different strictness properties in the presence of ⊥:
+These two forms are seemingly identical, but there is a subtle difference. The first one is just sugar for `op a`, while the second one is a lambda (and not direct application of `op`). This leads to different strictness properties in the presence of ⊥:
 
 ```haskell
 > let op = undefined


### PR DESCRIPTION
1. Removed the redundant "This leads to".
2. Fixed spelling error "seemingly".

You should consider rewriting this following sentence, because the double negatives make it difficult to parse for beginners:
    "you can't just look up the code and not understand how it's implemented."
