### PR TITLE
Fix typo in lens-infix-operators.md

### DIFF
--- a/lens-infix-operators.md
+++ b/lens-infix-operators.md
@@ -48,7 +48,7 @@ correct data type (which in particular starts witha capital letter).
 
 - `?!`: Unsafe version of `?`: crashes when there is no value.
 
- *Example:* `[1..10] ^?! folded` is `1`, while `[] ^? folded` is a runtime
+ *Example:* `[1..10] ^?! folded` is `1`, while `[] ^?! folded` is a runtime
             error.
 
 - `!`:  Perform a monadic action with the data.


### PR DESCRIPTION
I noticed the second example for `^?!` accidentally used `^?` instead.

I don't know why the last line of the file is being changed like that; maybe Github's built-in editor added a newline at the end?
