### PR TITLE
Getting rid of a redundant identity

### DIFF
--- a/second_functor_law.md
+++ b/second_functor_law.md
@@ -31,36 +31,20 @@ Pretty cool how something like that can be derived from a type alone!
 Similarly, you can generate the free theorem for `fmap`, which reads
 
 ```haskell
-        p .      q =      f .      g -- (1) Given this ...
-=> fmap p . fmap q = fmap f . fmap g -- (2) ... this holds
+        f .      g =      p .      q -- (1) Given this ...
+=> fmap f . fmap g = fmap p . fmap q -- (2) ... this holds
 ```
 
 In other words, this says that whenever functions compose, fmapping all of them
 still composes.
 
-We also have another trivial law,
+Now let's choose `p = id` and `q = f . g`, and then evaluate what we got for 2 steps 
 
 ```haskell
-         p . q  =       f . g  -- Given this (same as above) ...
-=> fmap (p . q) = fmap (f . g) -- (3) ... we can just apply fmap on
-                               -- both sides; referential transparency
-                               -- guarantees both sides stay equal
-```
-
-Now let's choose `p = id`, and we'll get
-
-```haskell
-fmap id . fmap q = fmap f . fmap g -- (2) specialized
-fmap (id . q) = fmap (f . g)       -- (3) specialized
-```
-
-Using the first `Functor` law, we can evaluate the first line, and in the
-second line `q` is simply composed with the identity. So evaluating both of
-these one step yields
-
-```haskell
-fmap q = fmap f . fmap g
-fmap q = fmap (f . g)
+   fmap f . fmap g
+ = fmap id . fmap (f . g) -- (2) specialized
+ = id . fmap (f . g) -- by the first functor law
+ = fmap (f . g)
 ```
 
 Since the left hand sides of both lines are equal so are their right hand sides,


### PR DESCRIPTION
If we set `q = f . g`, we don't need the equation (3) provided by referential transparency.
