### PR TITLE
Change possibly confusing variable naming

### DIFF
--- a/hindley-milner/src/HindleyMilner.hs
+++ b/hindley-milner/src/HindleyMilner.hs
@@ -157,7 +157,7 @@ instance IsString MType where
 freeMType :: MType -> Set Name
 freeMType = \case
     TVar a      -> [a]
-    TFun f x    -> freeMType f <> freeMType x
+    TFun a b    -> freeMType a <> freeMType b
     TList a     -> freeMType a
     TEither l r -> freeMType l <> freeMType r
     TTuple a b  -> freeMType a <> freeMType b


### PR DESCRIPTION
`f` and `x` make it look like a function and variable name instead of type variables in a function _type_. When referring to a function type, `a → b` is usually used, and that's in fact what's used in the comment just before.