### PR TITLE
Apply substitution before generalization (see issue #42)

### DIFF
--- a/hindley-milner/app/Main.hs
+++ b/hindley-milner/app/Main.hs
@@ -180,6 +180,6 @@ showType :: Env    -- ^ Starting environment, e.g. 'prelude'.
          -> Text   -- ^ Text representation of the result. Contains an error
                    --   message on failure.
 showType env expr =
-    case (runInfer . fmap (generalize (Env mempty) . snd) . infer env) expr of
+    case (runInfer . fmap (generalize (Env mempty) . uncurry applySubst) . infer env) expr of
         Left err -> "Error inferring type of " <> ppr expr <>": " <> ppr err
         Right ty -> ppr expr <> " :: " <> ppr ty


### PR DESCRIPTION
This change would apply (rather than discard) the top-level substitutions returned with the expression's inferred monotype prior to generalizing it to a polytype.