### PR TITLE
docs: `ord` should be `chr`

### DIFF
--- a/write_yourself_a_brainfuck.md
+++ b/write_yourself_a_brainfuck.md
@@ -457,7 +457,7 @@ specifying a source file with
    this? Hint: `Comment`s don't do anything and may save you from adding a
    `Maybe` type.
 
-2. (easy) The call to `ord` produces an error when applied to a negative
+2. (easy) The call to `chr` produces an error when applied to a negative
    element, and you probably won't want to print character number 9001 in
    Brainfuck ever anyway. How could you modify the command to constrain the
    output to ASCII?


### PR DESCRIPTION
This was a great tutorial to work through @quchen, thanks for putting it together!

I *think* you meant to say "The call to `chr`" instead of "The call to `ord`", but I could have misunderstood the exercise.